### PR TITLE
keep upstream compatibility

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -18,6 +18,11 @@ output "vnet_address_space" {
   value       = "${azurerm_virtual_network.vnet.address_space}"
 }
 
+output "vnet_subnets" {
+  description = "The ids of subnets created inside the newl vNet"
+  value       = "${azurerm_subnet.subnet.*.id}"
+}
+
 output "vnet_subnet_ids" {
   description = "The ids of subnets created inside the newl vNet"
   value       = "${zipmap(azurerm_subnet.subnet.*.name, azurerm_subnet.subnet.*.id)}"


### PR DESCRIPTION
we keep the output to ensure we don't break compatibility with Azure/terraform-azurerm-vnet